### PR TITLE
sqliteendorsements: fix test fails due to unstable ordering

### DIFF
--- a/common/query.go
+++ b/common/query.go
@@ -132,3 +132,22 @@ func ParseQueryDescriptors(claims map[string]interface{}, data []byte) ([]*Query
 
 	return qds, nil
 }
+
+// QueryDescriptorsByName implements sort.Interface for sorting query descriptors by name.
+type QueryDescriptorsByName []*QueryDescriptor
+
+// Len returns the length of QueryDescriptor slice to be sorted.
+func (q QueryDescriptorsByName) Len() int {
+	return len(q)
+}
+
+// Less returns true iff the QueryDescriptor at index i compares as "less" than the
+// one at index j, based on their names.
+func (q QueryDescriptorsByName) Less(i, j int) bool {
+	return q[i].Name < q[j].Name
+}
+
+// Swap swaps QueryDescriptors at the specified indexes.
+func (q QueryDescriptorsByName) Swap(i, j int) {
+	q[i], q[j] = q[j], q[i]
+}

--- a/plugins/sqliteendorsements/main_test.go
+++ b/plugins/sqliteendorsements/main_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -153,6 +154,8 @@ func TestParseQueryDescriptors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
+
+	sort.Sort(common.QueryDescriptorsByName(qds))
 
 	for i, qd := range qds {
 		eqd := expected_qds[i]


### PR DESCRIPTION
Sort parsed query descriptors before comparing them to expected values
to ensure stable ordering.