### PR TITLE
sqlitepolicy: fix store init in test

### DIFF
--- a/plugins/sqlitepolicy/main_test.go
+++ b/plugins/sqlitepolicy/main_test.go
@@ -70,7 +70,8 @@ func TestSqliteGetPolicy(t *testing.T) {
 	}
 	defer finiDb(dbPath)
 
-	pm, err := NewPolicyStore(common.PolicyStoreParams{"dbPath": dbPath})
+	var pm PolicyStore
+	err = pm.Init(common.PolicyStoreParams{"dbPath": dbPath})
 	if err != nil {
 		t.Errorf("%v", err)
 	}


### PR DESCRIPTION
The test seemed to have still been using an old initialisation mechanism
that no longer exists. Replace it with current Init().