### PR TITLE
cmd/endorsements: use NOP logger for tests

### DIFF
--- a/cmd/endorsements/main_test.go
+++ b/cmd/endorsements/main_test.go
@@ -72,10 +72,7 @@ func doRunCommand(command string, args []string) error {
 		return err
 	}
 
-	logger, err := zap.NewDevelopment()
-	if err != nil {
-		return err
-	}
+	logger := zap.NewNop()
 
 	err = runCommand(config, command, args, logger)
 	if err != nil {


### PR DESCRIPTION
Use NOP logger during testing to prevent intermittent logger output from
interfering with example results.