### PR TITLE
Add 'quiet' param for LoadPlugins

### DIFF
--- a/cmd/endorsements/main.go
+++ b/cmd/endorsements/main.go
@@ -110,16 +110,19 @@ func runListQueriesCommand(
 func runCommand(config *common.Config, command string, args []string, logger *zap.Logger) error {
 	var err error
 
+	quiet := true
 	if config.Debug {
 		if logger, err = zap.NewDevelopment(); err != nil {
 			return err
 		}
 		defer logger.Sync() //nolint
+
+		quiet = false
 	}
 
 	em := endorsement.NewManager()
 	if err := em.InitializeStore(
-		config.PluginLocations, config.EndorsementStoreName, config.EndorsementStoreParams,
+		config.PluginLocations, config.EndorsementStoreName, config.EndorsementStoreParams, quiet,
 	); err != nil {
 		return err
 	}

--- a/cmd/policy/main.go
+++ b/cmd/policy/main.go
@@ -26,7 +26,7 @@ func runCommand(config *common.Config, command string, args []string, logger *za
 
 	pm := policy.NewManager()
 	if err := pm.InitializeStore(
-		config.PluginLocations, config.PolicyStoreName, config.PolicyStoreParams,
+		config.PluginLocations, config.PolicyStoreName, config.PolicyStoreParams, false,
 	); err != nil {
 		return err
 	}
@@ -267,6 +267,7 @@ func runVerifyCommand(config *common.Config, args []string, pm *policy.Manager, 
 		config.PluginLocations,
 		config.PolicyEngineName,
 		config.PolicyEngineParams,
+		false,
 	)
 
 	if err != nil {

--- a/cmd/policy/main_test.go
+++ b/cmd/policy/main_test.go
@@ -87,7 +87,7 @@ func Test_PolicyTool_FullCycle(t *testing.T) {
 
 	pm := policy.NewManager()
 	err = pm.InitializeStore(
-		config.PluginLocations, config.PolicyStoreName, config.PolicyStoreParams,
+		config.PluginLocations, config.PolicyStoreName, config.PolicyStoreParams, true,
 	)
 	require.Nil(err)
 	defer pm.Close()

--- a/common/plugin.go
+++ b/common/plugin.go
@@ -40,7 +40,7 @@ type INamed interface {
 // LoadPlugin returns a pointer to a LoadedPlugin based on the plugin type and
 // names specfied, by search for a suitable plugin binary inside the provided
 // locations.
-func LoadPlugin(locations []string, plugType, plugName string) (*LoadedPlugin, error) {
+func LoadPlugin(locations []string, plugType, plugName string, quiet bool) (*LoadedPlugin, error) {
 
 	handshakeConfig := plugin.HandshakeConfig{
 		ProtocolVersion:  1,
@@ -48,10 +48,17 @@ func LoadPlugin(locations []string, plugType, plugName string) (*LoadedPlugin, e
 		MagicCookieValue: "VERAISON",
 	}
 
+	var logLevel hclog.Level
+	if quiet {
+		logLevel = hclog.Error
+	} else {
+		logLevel = hclog.Warn
+	}
+
 	logger := hclog.New(&hclog.LoggerOptions{
 		Name:   plugName,
 		Output: os.Stdout,
-		Level:  hclog.Warn,
+		Level:  logLevel,
 	})
 
 	for _, location := range locations {

--- a/common/policy.go
+++ b/common/policy.go
@@ -387,10 +387,11 @@ func LoadAndInitializePolicyEngine(
 	locations []string,
 	name string,
 	params PolicyEngineParams,
+	quiet bool,
 ) (IPolicyEngine, *plugin.Client, plugin.ClientProtocol, error) {
 	engineName := Canonize(name)
 
-	lp, err := LoadPlugin(locations, "policyengine", engineName)
+	lp, err := LoadPlugin(locations, "policyengine", engineName, quiet)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/endorsement/manager.go
+++ b/endorsement/manager.go
@@ -44,8 +44,9 @@ func (em *Manager) InitializeStore(
 	pluginLocaitons []string,
 	name string,
 	params common.EndorsementStoreParams,
+	quiet bool,
 ) error {
-	lp, err := common.LoadPlugin(pluginLocaitons, "endorsementstore", name)
+	lp, err := common.LoadPlugin(pluginLocaitons, "endorsementstore", name, quiet)
 	if err != nil {
 		return err
 	}

--- a/endorsement/manager_test.go
+++ b/endorsement/manager_test.go
@@ -76,7 +76,7 @@ func TestLoadStore(t *testing.T) {
 	pluginDir := filepath.Join(wd, "..", "plugins", "bin")
 
 	params := common.EndorsementStoreParams{"dbpath": dbPath}
-	err = pm.InitializeStore([]string{pluginDir}, "sqlite", params)
+	err = pm.InitializeStore([]string{pluginDir}, "sqlite", params, false)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/policy/manager.go
+++ b/policy/manager.go
@@ -26,10 +26,11 @@ func (pm *Manager) InitializeStore(
 	pluginLocaitons []string,
 	name string,
 	params common.PolicyStoreParams,
+	quiet bool,
 ) error {
 	name = common.Canonize(name)
 
-	lp, err := common.LoadPlugin(pluginLocaitons, "policystore", name)
+	lp, err := common.LoadPlugin(pluginLocaitons, "policystore", name, quiet)
 	if err != nil {
 		return err
 	}

--- a/policy/manager_test.go
+++ b/policy/manager_test.go
@@ -75,7 +75,7 @@ func TestPutPolicyBytesAndGetPolicy(t *testing.T) {
 	pluginDir := filepath.Join(wd, "..", "plugins", "bin")
 
 	params := common.PolicyStoreParams{"dbpath": dbPath}
-	err = pm.InitializeStore([]string{pluginDir}, "sqlite", params)
+	err = pm.InitializeStore([]string{pluginDir}, "sqlite", params, true)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}

--- a/tokenprocessor/processor.go
+++ b/tokenprocessor/processor.go
@@ -32,7 +32,7 @@ type LoadedExtractorPlugin struct {
 }
 
 func (tp *TokenProcessor) Init(config Config) error {
-	lp, err := common.LoadPlugin(config.PluginLocations, "trustanchorstore", config.TrustAnchorStoreName)
+	lp, err := common.LoadPlugin(config.PluginLocations, "trustanchorstore", config.TrustAnchorStoreName, false)
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func (tp TokenProcessor) GetExtractor(format common.TokenFormat) (common.IEviden
 		return extractorPlugin.Extractor, nil
 	}
 
-	lp, err := common.LoadPlugin(tp.PluginLocations, "evidenceextractor", format.String())
+	lp, err := common.LoadPlugin(tp.PluginLocations, "evidenceextractor", format.String(), false)
 	if err != nil {
 		return nil, err
 	}

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -40,11 +40,17 @@ func (v *Verifier) Initialize(vc Config) error {
 		vc.PluginLocations,
 		vc.EndorsementStoreName,
 		vc.EndorsementStoreParams,
+		false,
 	); err != nil {
 		return err
 	}
 
-	if err := v.pm.InitializeStore(vc.PluginLocations, vc.PolicyStoreName, vc.PolicyStoreParams); err != nil {
+	if err := v.pm.InitializeStore(
+		vc.PluginLocations,
+		vc.PolicyStoreName,
+		vc.PolicyStoreParams,
+		false,
+	); err != nil {
 		return err
 	}
 
@@ -52,6 +58,7 @@ func (v *Verifier) Initialize(vc Config) error {
 		vc.PluginLocations,
 		vc.PolicyEngineName,
 		vc.PolicyEngineParams,
+		false,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Plugins use a different logger form the rest of the framework due to the
fact that they run in a different process. Add a 'quiet' flag to
LoadPlugins (and expose it via appropriate InializeStore() methods) to
allow suppressing output from the plugin.

(Note such output can always be considered to be "debug", as any actual
issue will be propagated as errors to the main process).

This is primarily to allow suppressing of intermittent output for
testing.