### PR TITLE
Rename `complete` status to `success`

### DIFF
--- a/docs/api/endorsement-provisioning/README.md
+++ b/docs/api/endorsement-provisioning/README.md
@@ -128,7 +128,7 @@ format is CoRIM.
   Content-Type: application/vnd.veraison.provisioning-session+json
 
   {
-    "status": "complete",
+    "status": "success",
     "expiry": "2030-10-12T07:20:50.52Z"
   }
 ```

--- a/docs/api/endorsement-provisioning/README.md
+++ b/docs/api/endorsement-provisioning/README.md
@@ -27,7 +27,7 @@ format is CoRIM.
 /|\ ------------------------>| /submit     |
 / \ <------------------------|             |
             200 (OK)         '-------------' 
-            { "status": ... }
+            { "status": "success|failed" }
 ```
 
 * Client submits the endorsement provisioning request

--- a/docs/api/endorsement-provisioning/README.md
+++ b/docs/api/endorsement-provisioning/README.md
@@ -4,39 +4,39 @@ The API described here are can be used to provision
 Endorsements into a Verifier. The API are agnostic with regards to 
 the specific data model used to transport Endorsements. HTTP Content negotiation is used to determine the precise message structure and format of the information exchanged between the clients and the server. 
 One specific example of information exchange using
-[Concise Reference Integrity Manifest](https://datatracker.ietf.org/doc/draft-birkholz-rats-corim/) is given below.
+[Concise Reference Integrity Manifest (CoRIM)](https://datatracker.ietf.org/doc/draft-birkholz-rats-corim/) is given below.
 
 ## Provisioning API
 
-The provisioning API allows authorised supply chain actors to communicate reference and endorsed values,
+The provisioning API allows authorized supply chain actors to communicate reference and endorsed values,
 verification and identity key material, as well as other kinds of endorsements to Veraison. The supported 
 format is CoRIM.
 
 * To initiate a provisioning session, a client `POST`'s the CoRIM containing the endorsements to be provisioned to the `/submit` URL.
-* If the transaction completes synchronously, a `200` response is returned to the client to indicate a
-  successful submission of the posted CoRIM.
-* For large submissions with multiple CoRIMs, the provisioning processing may happen in background. In this case,
-  the Server returns a `201` response, with a `Location` header pointing to a "session" resource.  This "session" resource is only active for a given amount of time. Client can poll the resource to query the status of the submission request until the session completes.
-* A session can be in one of the following states: `processing`, `complete`, or `failed`.
-* The resource has a defined "time to live": upon its expiry, the resource is garbage collected.
-* Client can continue periodic polling of the session uri, until the processing is either `complete` or `failed`.
-
+* If the transaction completes synchronously, a `200` response is returned to the client to indicate the
+  submission of the posted CoRIM has been fully processed.  The response body contains a "session" resource whose `status` field encodes the outcome of the submission (see below).
+* The provisioning processing may also happen asynchronously, for example when submitting a large CoRIM. In this case,
+  the server returns a `201` response, with a `Location` header pointing to a session resource that the client can regularly poll to monitor any change in the status of its request.
+* A session starts in `processing` state and ends up in one of `success` or `failed`. When in `failed` state, the `failure-reason` field of the session resource contains details about the error condition.
+* The session resource has a defined time to live: upon its expiry, the resource is garbage collected.  Alternatively, the client can dispose the session resource by issuing a `DELETE` to the resource URI.
 
 ## Synchronous submission
 
-```
+```text
  o        (1) POST           .-------------.
 /|\ ------------------------>| /submit     |
 / \ <------------------------|             |
             200 (OK)         '-------------' 
-
+            { "status": ... }
 ```
 
 * Client submits the endorsement provisioning request
-* Server responds with response code `200` indicating successful submission. 
-  The transaction is complete
-  
-```
+* Server responds with response code `200` indicating processing is complete.
+  The response body contains a session resource with a `status` indicating the outcome of the submission operation.
+
+### Example of a successful submission
+
+```text
 >> Request:
   POST /endorsement-provisioning/v1/submit
   Host: veraison.example
@@ -46,29 +46,59 @@ format is CoRIM.
 
 << Response:
   HTTP/1.1 200 OK
+  Content-Type: application/vnd.veraison.provisioning-session+json
+
+  {
+    "status": "success",
+    "expiry": "1970-01-01T00:00:00Z"
+  }
+```
+
+### Example of a failed submission
+
+```text
+>> Request:
+  POST /endorsement-provisioning/v1/submit
+  Host: veraison.example
+  Content-Type: application/rim+cbor
+
+  ...CoRIM as binary data...
+
+<< Response:
+  HTTP/1.1 200 OK
+  Content-Type: application/vnd.veraison.provisioning-session+json
+
+  {
+    "status": "failed",
+    "failure-reason": "invalid signature",
+    "expiry": "1970-01-01T00:00:00Z"
+  }
 ```
 
 ## Asynchronous submission
 
-```
+```text
  o        (1) POST           .-------------.
 /|\ ------------------------>| /submit     |
 / \ \ <----------------------|             |
-   \ \      201 ( Session )  '-------------' 
-    \ \                             |
+   \ \      201 Created      '-------------'
+    \ \     Location: /session/01   |
      \ \                            V
       \ \  (2) GET           .-------------.
        \ '------------------>| /session/01 |
         `<-------------------|             |
-             200 (OK)        '-------------'
-             status= "complete"
+             200 OK          '-------------'
+             { "status": ... }
 ```
 
 * Client submits the endorsement provisioning request
 * Server responds with response code `201` indicating that the request has been accepted and will be processed asynchronously
-* Server returns a time-bound session resource in the `Location` header. The resource can be polled at regular intervals to check the progress of the submission, until the processing is complete (either successfully or with a failure)
+* Server returns the URI of a time-bound session resource in the `Location` header. The resource can be polled at regular intervals to check the progress of the submission, until the processing is complete (either successfully or with a failure)
 
-```
+### Example
+
+
+```text
 >> Request:
   POST /endorsement-provisioning/v1/submit
   Host: veraison.example
@@ -87,8 +117,7 @@ format is CoRIM.
   }
 ```
 
-### Polling the session resource
-```
+```text
 >> Request:
   GET /endorsement-provisioning/v1/session/1234567890
   Host: veraison.example

--- a/docs/api/endorsement-provisioning/README.md
+++ b/docs/api/endorsement-provisioning/README.md
@@ -88,7 +88,7 @@ format is CoRIM.
        \ '------------------>| /session/01 |
         `<-------------------|             |
              200 OK          '-------------'
-             { "status": ... }
+             { "status": "processing|success|failed" }
 ```
 
 * Client submits the endorsement provisioning request

--- a/docs/api/endorsement-provisioning/endorsement-provisioning.yaml
+++ b/docs/api/endorsement-provisioning/endorsement-provisioning.yaml
@@ -25,6 +25,10 @@ paths:
           description: >
             The supplied CoRIM has been successfully provisioned in
             the Verifier. The transaction is complete.
+          content:
+            application/vnd.veraison.provisioning-session+json:
+              schema:
+                $ref: './schemas/components.yaml#/components/schemas/SessionResource'
         '201':
           description: >
             The submission is successful and will be processed
@@ -41,7 +45,7 @@ paths:
                 subsequent status check. (The current content of the
                 resource is returned in the response body.)
           content:
-            provisioning-session+json:
+            application/vnd.veraison.provisioning-session+json:
               schema:
                 $ref: './schemas/components.yaml#/components/schemas/SessionResource'
         default:
@@ -57,7 +61,7 @@ paths:
           description: >
             The endorsement provisioning session resource
           content:
-            provisioning-session+json:
+            application/vnd.veraison.provisioning-session+json:
               schema:
                 $ref: './schemas/components.yaml#/components/schemas/SessionResource'
         default:

--- a/docs/api/endorsement-provisioning/schemas/components.yaml
+++ b/docs/api/endorsement-provisioning/schemas/components.yaml
@@ -22,7 +22,7 @@ components:
             the endorsement provisioning session expires and may no longer exist. The
             client MUST assume that the endorsement provisioning session resource is
             garbage-collected at the specified time.
-        details:
+        failure-reason:
           type: string
           description: >
             Optional field to provide more details about the failure cause when provisioning status is `failed`

--- a/docs/api/endorsement-provisioning/schemas/components.yaml
+++ b/docs/api/endorsement-provisioning/schemas/components.yaml
@@ -9,12 +9,11 @@ components:
           type: string
           enum:
             - processing
-            - complete
+            - success
             - failed
           description: >
-            For a payload submission 'status' processing reflects that provisioning is in progress
-            Upon successful completion of the provisioning, status moves to completed, else
-            failed.
+            For a payload submission, a status `processing` reflects that provisioning is in progress.
+            Upon successful completion of the provisioning, status moves to `success`, else to `failed`.
         expiry:
           type: string
           format: date-time


### PR DESCRIPTION
A status `failed` is `complete` too.  So, moving to a more meaningful string to describe successful completion of the submission.

Also further adjustments associated with the work done in https://github.com/veraison/apiclient/issues/5