### PR TITLE
install golangci using the `install.sh` script from the golangci repo

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install golangci-lint 
       run: |
         go version
-        curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.8
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:


### PR DESCRIPTION
also bump the version to latest (1.43.0)

Fix #108