### PR TITLE
Fix broken link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ There is also an allegorical aspect about good/bad verifications being reflected
 
 # Documentation
 
-You can access Veraison documentation under [docs](https://github.com/veraison/docs/README.md).
+You can access Veraison documentation under [docs](https://github.com/veraison/docs/blob/main/README.md).
 
 # Maintainers
 


### PR DESCRIPTION
This fix is required, as with the recent change the links to docs README.md is broken.