### PR TITLE
Merge the Provisioner service into VTS

### DIFF
--- a/cmd/vts/main.go
+++ b/cmd/vts/main.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -16,7 +15,6 @@ import (
 
 // TODO this a very minimal "frontend" implementation.
 func main() {
-
 	configPaths := common.NewConfigPaths()
 
 	flag.Var(configPaths, "config", "Path to direcotory containing the config file(s).")
@@ -45,11 +43,6 @@ func main() {
 	}
 
 	server := trustedservices.RPCServer{}
-	ctx := context.Background()
-
-	if _, err := server.Init(ctx, clientParams); err != nil {
-		log.Fatalf("could not initialize store: %v", err)
-	}
 
 	grpcServer := grpc.NewServer()
 	common.RegisterVTSServer(grpcServer, &server)
@@ -57,6 +50,4 @@ func main() {
 	if err := grpcServer.Serve(listener); err != nil {
 		log.Fatalf("server error: %v", err)
 	}
-
-	server.Close(ctx, nil)
 }

--- a/common/vts.proto
+++ b/common/vts.proto
@@ -12,23 +12,6 @@ import "param.proto";
 import "token.proto";
 
 
-message InitResponse {
-}
-
-message CloseArgs {
-}
-
-message CloseResponse {
-    Status status = 1;
-}
-
-message OpenArgs {
-}
-
-message OpenResponse {
-    Status status = 1;
-}
-
 enum TAType {
     TA_UNSPECIFIED = 0;
     TA_RAWPUBLICKEY = 1;
@@ -121,29 +104,17 @@ message GetTrustAnchorResponse {
     TrustAnchorValue value = 2;
 }
 
-// Provisioner is the Service end point that is used to store
-// and retrieve Software Components and Trust Anchors to and from
-// the Endorsement Store
-service Provisioner {
+// Client interface for the Veraison Trusted Services component.
+service VTS {
+    // Returns attestation information -- evidences, endorsed claims, trust
+    // vector, etc -- for the provided attestation token data.
+    rpc GetAttestation(AttestationToken) returns (Attestation);
+
+    // Service endpoints that are used to store and retrieve Software Components
+    // and Trust Anchors to and from the endorsement store
     rpc AddSwComponents(AddSwComponentsRequest) returns (AddSwComponentsResponse);
     rpc GetSwComponent(GetSwComponentRequest)  returns (GetSwComponentResponse);
     rpc AddTrustAnchor(AddTrustAnchorRequest) returns (AddTrustAnchorResponse);
     rpc GetTrustAnchor(GetTrustAnchorRequest) returns (GetTrustAnchorResponse);
-}
-
-service Store {
-	rpc Open(OpenArgs) returns (OpenResponse);
-	rpc Close(CloseArgs) returns (CloseResponse);
-}
-
-// Client interface for the Veraison Trusted Services component.
-service VTS {
-	rpc Init(ParamStore) returns (InitResponse);
-
-	// Returns attestation information -- evidences, endorsed claims, trust
-	// vector, etc -- for the provided attestation token data.
-	rpc GetAttestation(AttestationToken) returns (Attestation);
-
-	rpc Close(CloseArgs) returns (CloseResponse);
 }
 

--- a/provisioning/api/handler_test.go
+++ b/provisioning/api/handler_test.go
@@ -8,6 +8,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/gin-gonic/gin"
 	"github.com/golang/mock/gomock"
 	"github.com/moogar0880/problems"
@@ -15,18 +19,15 @@ import (
 	"github.com/veraison/common"
 	mock_deps "github.com/veraison/veraison/provisioning/api/mocks"
 	"github.com/veraison/veraison/provisioning/decoder"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 var (
 	testGoodDecoderResponse = decoder.EndorsementDecoderResponse{
 		TrustAnchors: []*common.TrustAnchor{
-			&common.TrustAnchor{},
+			{},
 		},
 		SwComponents: []*common.SwComponent{
-			&common.SwComponent{},
+			{},
 		},
 	}
 	testFailedTaRes = common.AddTrustAnchorResponse{
@@ -377,7 +378,7 @@ func TestHandler_Submit_store_AddSwComponents_failure1(t *testing.T) {
 			gomock.Eq(
 				&common.AddSwComponentsRequest{
 					Info: []*common.SwComponent{
-						&common.SwComponent{},
+						{},
 					},
 				},
 			),
@@ -452,7 +453,7 @@ func TestHandler_Submit_store_AddSwComponents_failure2(t *testing.T) {
 			gomock.Eq(
 				&common.AddSwComponentsRequest{
 					Info: []*common.SwComponent{
-						&common.SwComponent{},
+						{},
 					},
 				},
 			),
@@ -525,7 +526,7 @@ func TestHandler_Submit_ok(t *testing.T) {
 			gomock.Eq(
 				&common.AddSwComponentsRequest{
 					Info: []*common.SwComponent{
-						&common.SwComponent{},
+						{},
 					},
 				},
 			),

--- a/provisioning/storeclient/dummy.go
+++ b/provisioning/storeclient/dummy.go
@@ -4,6 +4,7 @@ package storeclient
 
 import (
 	"context"
+	"errors"
 	"log"
 
 	"github.com/veraison/common"
@@ -69,28 +70,10 @@ func (o *Dummy) GetSwComponent(
 	}, nil
 }
 
-func (o *Dummy) Open(
+func (o *Dummy) GetAttestation(
 	ctx context.Context,
-	in *common.OpenArgs,
+	in *common.AttestationToken,
 	opts ...grpc.CallOption,
-) (*common.OpenResponse, error) {
-	// always return a successful response
-	return &common.OpenResponse{
-		Status: &common.Status{
-			Result: true,
-		},
-	}, nil
-}
-
-func (o *Dummy) Close(
-	ctx context.Context,
-	in *common.CloseArgs,
-	opts ...grpc.CallOption,
-) (*common.CloseResponse, error) {
-	// always return a successful response
-	return &common.CloseResponse{
-		Status: &common.Status{
-			Result: true,
-		},
-	}, nil
+) (*common.Attestation, error) {
+	return nil, errors.New("not implemented")
 }

--- a/provisioning/storeclient/istoreclient.go
+++ b/provisioning/storeclient/istoreclient.go
@@ -7,6 +7,5 @@ import (
 )
 
 type IStoreClient interface {
-	common.ProvisionerClient
-	common.StoreClient
+	common.VTSClient
 }

--- a/trustedservices/rpc.go
+++ b/trustedservices/rpc.go
@@ -31,17 +31,9 @@ type RPCServer struct {
 	Client *LocalClient
 }
 
-func (c *RPCServer) Init(ctx context.Context, params *common.ParamStore) (*common.InitResponse, error) {
-	return nil, nil
-}
 func (c *RPCServer) GetAttestation(
 	ctx context.Context,
 	token *common.AttestationToken,
 ) (*common.Attestation, error) {
 	return c.Client.GetAttestation(token)
-}
-
-func (c *RPCServer) Close(ctx context.Context, args *common.CloseArgs) (*common.CloseResponse, error) {
-	err := c.Client.Close()
-	return nil, err
 }


### PR DESCRIPTION
This change merges the Provisioner service into VTS.  It also removes
the Store service, and drops Init and Close from the set of VTS's
exposed RPC endpoints.