### PR TITLE
Corrected the path for the `common` module

### DIFF
--- a/common/go.mod
+++ b/common/go.mod
@@ -1,4 +1,4 @@
-module github.com/veraison/common
+module github.com/veraison/veraison/common
 
 go 1.15
 


### PR DESCRIPTION
When using Veraison from an external project, it attempts to pull the `common` module, but the path in the `go.mod` file seems to be incorrect (`go mod vendor` complains about it, at least).
Looking at the `common/go.mod` file, the path does indeed appear to be incorrect.